### PR TITLE
Fix toast listener leak

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -179,7 +179,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- fix infinite listener registration in `useToast`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*